### PR TITLE
README: need deb-src for InRelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The most direct solution is to add sid to your `/etc/apt/sources.list` file, the
 
 ```
 # echo 'deb http://deb.debian.org/debian sid main' >> /etc/apt/sources.list
+# echo 'deb-src http://deb.debian.org/debian sid main' >> /etc/apt/sources.list
 # echo 'APT::Default-Release "stable";' >> /etc/apt/apt.conf
 # apt update
 $ ratt ...


### PR DESCRIPTION
Without a `deb-src` entry for the target dist [this apt-get indextargets command](https://github.com/Debian/ratt/blob/master/ratt.go#L220-L225) will not return any files which will lead to the dreaded `Could not find InRelease file` error.