### PR TITLE
Use apt-helper cat-file to handle compressed APT index files for dose-ceve

### DIFF
--- a/ratt.go
+++ b/ratt.go
@@ -133,6 +133,27 @@ func fallback(sourcesPaths []string, binaries []string) (map[string][]version.Ve
 	return rebuild, nil
 }
 
+func resolveAptListFile(indexFilePath string) (string, error) {
+	cmd := exec.Command("/usr/lib/apt/apt-helper", "cat-file", indexFilePath)
+	resolvedContent, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to read apt file %s: %w", indexFilePath, err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "apt-index-resolved-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	if _, err := tmpFile.Write(resolvedContent); err != nil {
+		tmpFile.Close()
+		return "", fmt.Errorf("failed to write file content: %w", err)
+	}
+
+	tmpFile.Close()
+	return tmpFile.Name(), nil
+}
+
 func reverseBuildDeps(packagesPaths, sourcesPaths []string, binaries []string) (map[string][]version.Version, error) {
 	if _, err := exec.LookPath("dose-ceve"); err != nil {
 		log.Printf("dose-ceve(1) not found. Please install the dose-extra package for more accurate results. Falling back to interpreting Sources directly")
@@ -152,11 +173,33 @@ func reverseBuildDeps(packagesPaths, sourcesPaths []string, binaries []string) (
 		"-T", "debsrc",
 		"-r", strings.Join(binaries, ","),
 		"-G", "pkg")
+
+	// keep track of temp files to delete them later
+	var tempPaths []string
+	defer func() {
+		for _, path := range tempPaths {
+			os.Remove(path)
+		}
+	}()
+
 	for _, packagesPath := range packagesPaths {
-		ceve.Args = append(ceve.Args, "deb://"+packagesPath)
+		resolvedPath, err := resolveAptListFile(packagesPath)
+		if err != nil {
+			log.Printf("failed to resolve %s: %v", packagesPath, err)
+			continue
+		}
+		tempPaths = append(tempPaths, resolvedPath)
+		ceve.Args = append(ceve.Args, "deb://"+resolvedPath)
 	}
+
 	for _, sourcesPath := range sourcesPaths {
-		ceve.Args = append(ceve.Args, "debsrc://"+sourcesPath)
+		resolvedPath, err := resolveAptListFile(sourcesPath)
+		if err != nil {
+			log.Printf("failed to resolve %s: %v", sourcesPath, err)
+			continue
+		}
+		tempPaths = append(tempPaths, resolvedPath)
+		ceve.Args = append(ceve.Args, "debsrc://"+resolvedPath)
 	}
 	ceve.Stderr = os.Stderr
 


### PR DESCRIPTION
APT index files under `/var/lib/apt/lists` (e.g., **Packages**, **Sources**) may be compressed depending on config like `Acquire::gzipIndexes`.

This pull request adds a helper that uses `/usr/lib/apt/apt-helper cat-file` to read and decompress these files transparently, writing the output to temporary files.

These temporary files are then passed as inputs to **dose-ceve** via the `debsrc://` and `deb://` URI schemes, ensuring **dose-ceve** always receives uncompressed, readable data.

Closes: #24