### PR TITLE
Add json output support for dry-run mode

### DIFF
--- a/docs/ratt.rst
+++ b/docs/ratt.rst
@@ -20,7 +20,7 @@ SYNOPSIS
         [-dist DIST] [-sbuild_dist DIST]
         [-log_dir DIR] [-chdist NAME]
         [-direct-rdeps] [-rdeps-depth N]
-        <file>.changes
+        [-json] <file>.changes
 
 DESCRIPTION
 ===========
@@ -76,6 +76,12 @@ OPTIONS
  included.  See the ``--depth`` option in ``dose-ceve(1)`` manpage to see
  more details.
 
+**-json**
+ Output results in JSON format (currently only works in combination with
+ `-dry_run`). JSON is written to stdout; human-readable logs go to stderr. Each
+ entry includes the reverse build-dependency name, its version, and the
+ corresponding `sbuild` command that would be executed.
+
 Using `-chdist` for Suite Isolation
 ===================================
 
@@ -122,6 +128,18 @@ Skip packages known FTBFS::
 Limit to direct reverse build-dependencies only::
 
   $ ratt -direct-rdeps yourpackage_*.changes
+
+Print dry-run result in JSON format::
+
+  $ ratt -dry_run -json yourpackage_*.changes
+
+Suppress all logs and print only JSON (clean output)::
+
+  $ ratt -dry_run -json yourpackage_*.changes 2>/dev/null
+
+Extract only the sbuild commands (with jq)::
+
+  $ ratt -dry_run -json yourpackage_*.changes 2>/dev/null | jq -r '.dry_run_builds[].sbuild_command'
 
 Filter specific packages::
 

--- a/sbuild.go
+++ b/sbuild.go
@@ -17,27 +17,35 @@ type sbuild struct {
 	extraDebs []string
 }
 
-func (s *sbuild) build(sourcePackage string, version *version.Version) *buildResult {
-	result := &buildResult{
-		src:     sourcePackage,
-		version: version,
-	}
+func (s *sbuild) buildCommandLine(sourcePackage string, version *version.Version) []string {
 	target := fmt.Sprintf("%s_%s", sourcePackage, version)
 	// TODO: discard resulting package immediately?
-	args := []string{
+	cmd := []string{
+		"sbuild",
 		"--arch-all",
 		"--dist=" + s.dist,
 		"--nolog",
 		target,
 	}
 	for _, filename := range s.extraDebs {
-		args = append(args, fmt.Sprintf("--extra-package=%s", filename))
+		cmd = append(cmd, fmt.Sprintf("--extra-package=%s", filename))
 	}
-	cmd := exec.Command("sbuild", args...)
+	return cmd
+}
+
+func (s *sbuild) build(sourcePackage string, version *version.Version) *buildResult {
+	result := &buildResult{
+		src:     sourcePackage,
+		version: version,
+	}
+	commandLine := s.buildCommandLine(sourcePackage, version)
 	if s.dryRun {
-		log.Printf("  commandline: %v\n", cmd.Args)
+		log.Printf("  commandline: %v\n", commandLine)
 		return result
 	}
+
+	cmd := exec.Command(commandLine[0], commandLine[1:]...)
+	target := fmt.Sprintf("%s_%s", sourcePackage, version)
 
 	buildlog, err := os.Create(filepath.Join(s.logDir, target))
 	defer buildlog.Close()


### PR DESCRIPTION
This commit introduces a `-json` flag that, when used together with `-dry_run`, outputs the dry-run results in structured JSON format to stdout.

This facilitates integration with CI tools and scripts by providing a structured output.

Example output:

```
{
  "dry_run_builds": [
    {
      "package": "foo",
      "sbuild_command": "sbuild..."
    },
    {
      "package": "bar",
      "sbuild_command": "sbuild..."
    }
  ]
}
```