### PR TITLE
Add -sbuild-keep-build-log option

### DIFF
--- a/docs/ratt.rst
+++ b/docs/ratt.rst
@@ -17,7 +17,7 @@ SYNOPSIS
 
    ratt [-h] [-dry_run] [-recheck] [-skip_ftbfs]
         [-include REGEX] [-exclude REGEX]
-        [-dist DIST] [-sbuild_dist DIST]
+        [-dist DIST] [-sbuild_dist DIST] [-sbuild-keep-build-log]
         [-log_dir DIR] [-chdist NAME]
         [-direct-rdeps] [-rdeps-depth N]
         [-json] <file>.changes
@@ -65,6 +65,10 @@ OPTIONS
 
 **-skip_ftbfs**
  Skip packages marked as FTBFS on udd.debian.org.
+
+**-sbuild-keep-build-log**
+ Let sbuild produce its ``.build`` log. Without this option, ratt passes
+ sbuild's ``--nolog`` and saves console output in ``-log_dir`` instead.
 
 **-direct-rdeps**
  Limit the reverse dependency analysis to packages that directly Build-Depend
@@ -124,6 +128,10 @@ Dry run::
 Skip packages known FTBFS::
 
   $ ratt -skip_ftbfs -chdist sid yourpackage_*.changes
+
+Keep sbuild .build logs::
+
+  $ ratt -sbuild-keep-build-log yourpackage_*.changes
 
 Limit to direct reverse build-dependencies only::
 

--- a/ratt.go
+++ b/ratt.go
@@ -84,6 +84,10 @@ var (
 		false,
 		"Filter out packages tagged as FTBFS from udd.debian.org")
 
+	sbuildKeepBuildLog = flag.Bool("sbuild-keep-build-log",
+		false,
+		"Let sbuild create its .build log. Without this option, ratt passes sbuild's --nolog and saves console output in -log_dir instead")
+
 	directRdeps = flag.Bool("direct-rdeps",
 		false,
 		"Limit reverse dependency analysis to packages that directly Build-Depend on the target. Equivalent to --rdeps-depth=2")
@@ -561,6 +565,7 @@ func main() {
 	builder := &sbuild{
 		dist:      *sbuildDist,
 		logDir:    *logDir,
+		keepBuildLog:  *sbuildKeepBuildLog,
 		dryRun:    *dryRun,
 		extraDebs: debs,
 	}
@@ -618,6 +623,7 @@ func main() {
 		recheckBuilder := &sbuild{
 			dist:   *sbuildDist,
 			logDir: *logDir + "_recheck",
+			keepBuildLog: *sbuildKeepBuildLog,
 			dryRun: false,
 		}
 		if err := os.MkdirAll(recheckBuilder.logDir, 0755); err != nil {


### PR DESCRIPTION
By default, ratt passes sbuild's `--nolog`, preventing .build logs from being generated and instead saving console output to `-log_dir`

This PR adds a `-sbuild-keep-build-log` option so users can disable this behavior, letting sbuild produce its own `.build` logs for each reverse build-dependency.

Useful in setups where the sbuild command is extracted from ratt and run in separate jobs (for instance, in salsa-ci), where `--nolog` would otherwise prevent the `.build` artifact from being created.