### PR TITLE
Add parallel build support with -parallel and -jobs options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,20 @@
 module github.com/Debian/ratt
 
-go 1.18
+go 1.24.0
 
-require pault.ag/go/debian v0.12.0
+toolchain go1.24.9
+
+require (
+	golang.org/x/sync v0.17.0
+	pault.ag/go/archive v0.0.0-20200912011324-7149510a39c7
+	pault.ag/go/debian v0.12.0
+)
 
 require (
 	github.com/DataDog/zstd v1.4.8 // indirect
 	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
-	pault.ag/go/archive v0.0.0-20200912011324-7149510a39c7 // indirect
 	pault.ag/go/blobstore v0.0.0-20180314122834-d6d187c5a029 // indirect
 	pault.ag/go/topsort v0.0.0-20160530003732-f98d2ad46e1a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/ratt.go
+++ b/ratt.go
@@ -21,9 +21,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
+	"golang.org/x/sync/errgroup"
 	"pault.ag/go/archive"
 	"pault.ag/go/debian/control"
 	"pault.ag/go/debian/version"
@@ -105,6 +108,14 @@ var (
 		false,
 		"Output results in JSON format (currently only works in combination with -dry_run)")
 
+	parallel = flag.Bool("parallel",
+		false,
+		"Build packages in parallel")
+
+	jobs = flag.Int("jobs",
+		runtime.NumCPU(),
+		"Number of parallel build jobs (default: number of CPU cores)")
+
 	listsPrefixRe = regexp.MustCompile(`/([^/]*_dists_.*)_InRelease$`)
 )
 
@@ -121,17 +132,17 @@ type ftbfsBug struct {
 func getFTBFSFromUDD(codename string) (map[string]struct{}, error) {
 	baseURL := "https://udd.debian.org/bugs/"
 	params := url.Values{
-		"release":             {codename},
-		"ftbfs":               {"only"},
-		"notmain":             {"ign"},
-		"merged":              {""},
-		"fnewerval":           {"7"},
-		"flastmodval":         {"7"},
-		"rc":                  {"1"},
-		"sortby":              {"id"},
-		"caffected_packages":  {"1"},
-		"sorto":               {"asc"},
-		"format":              {"json"},
+		"release":            {codename},
+		"ftbfs":              {"only"},
+		"notmain":            {"ign"},
+		"merged":             {""},
+		"fnewerval":          {"7"},
+		"flastmodval":        {"7"},
+		"rc":                 {"1"},
+		"sortby":             {"id"},
+		"caffected_packages": {"1"},
+		"sorto":              {"asc"},
+		"format":             {"json"},
 	}
 
 	fullURL := baseURL + "?" + params.Encode()
@@ -497,11 +508,63 @@ func normalizeSbuildDist(dist string) string {
 	return dist
 }
 
+func buildPackages(builder *sbuild, rebuild map[string][]version.Version, numJobs int) (map[string]*buildResult, []dryRunBuild) {
+	var eg errgroup.Group
+	eg.SetLimit(numJobs)
+
+	buildresults := make(map[string]*buildResult)
+	var dryRunBuilds []dryRunBuild
+	var resultsMu sync.Mutex
+	var cntMu sync.Mutex
+	cnt := 1
+
+	for src, versions := range rebuild {
+		eg.Go(func() error {
+			sort.Sort(sort.Reverse(version.Slice(versions)))
+			newest := versions[0]
+
+			cntMu.Lock()
+			currentCnt := cnt
+			cnt++
+			cntMu.Unlock()
+
+			log.Printf("Building package %d of %d: %s\n", currentCnt, len(rebuild), src)
+			result := builder.build(src, &newest)
+			if result.err != nil {
+				log.Printf("building %s failed: %v\n", src, result.err)
+			}
+
+			resultsMu.Lock()
+			defer resultsMu.Unlock()
+			buildresults[src] = result
+			if *dryRun {
+				cmd := builder.buildCommandLine(src, &newest)
+				dryRunBuilds = append(dryRunBuilds, dryRunBuild{
+					Package:       src,
+					Version:       newest.String(),
+					SbuildCommand: strings.Join(cmd, " "),
+				})
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		log.Printf("Error during parallel build: %v\n", err)
+	}
+	log.Printf("Completed building %d packages with %d workers\n", len(buildresults), numJobs)
+	return buildresults, dryRunBuilds
+}
+
 func main() {
 	flag.Parse()
 
 	if *jsonOutput && !*dryRun {
 		log.Fatal("-json can only be used together with -dry_run")
+	}
+
+	if *jobs <= 0 {
+		log.Fatal("-jobs must be a positive number")
 	}
 
 	if flag.NArg() == 0 {
@@ -650,38 +713,25 @@ func main() {
 	}
 
 	builder := &sbuild{
-		dist:      sbuildDistNorm,
-		logDir:    *logDir,
-		keepBuildLog:  *sbuildKeepBuildLog,
-		dryRun:    *dryRun,
-		extraDebs: debs,
+		dist:              sbuildDistNorm,
+		logDir:            *logDir,
+		keepBuildLog:      *sbuildKeepBuildLog,
+		dryRun:            *dryRun,
+		extraDebs:         debs,
 		extraExperimental: extraExperimental,
 		extraPockets:      extraPockets,
 		pocketsCodename:   pocketsCodename,
 	}
-	cnt := 1
+
 	buildresults := make(map[string](*buildResult))
 	var dryRunBuilds []dryRunBuild
-	for src, versions := range rebuild {
-		sort.Sort(sort.Reverse(version.Slice(versions)))
-		newest := versions[0]
-		log.Printf("Building package %d of %d: %s \n", cnt, len(rebuild), src)
-		cnt++
-		result := builder.build(src, &newest)
-		if result.err != nil {
-			log.Printf("building %s failed: %v\n", src, result.err)
-		}
-		buildresults[src] = result
 
-		if *dryRun {
-			cmd := builder.buildCommandLine(src, &newest)
-			dryRunBuilds = append(dryRunBuilds, dryRunBuild{
-				Package:       src,
-				Version:       newest.String(),
-				SbuildCommand: strings.Join(cmd, " "),
-			})
-		}
+	numJobs := 1
+	if *parallel {
+		numJobs = *jobs
+		log.Printf("Building packages in parallel using %d workers\n", numJobs)
 	}
+	buildresults, dryRunBuilds = buildPackages(builder, rebuild, numJobs)
 
 	var toInclude []string
 	for src, result := range buildresults {
@@ -695,8 +745,8 @@ func main() {
 
 	if *dryRun && *jsonOutput {
 		out, err := json.MarshalIndent(struct {
-			ReverseDepCount     int           `json:"reverse_dep_count"`
-			Builds              []dryRunBuild `json:"dry_run_builds"`
+			ReverseDepCount int           `json:"reverse_dep_count"`
+			Builds          []dryRunBuild `json:"dry_run_builds"`
 		}{
 			Builds:          dryRunBuilds,
 			ReverseDepCount: len(dryRunBuilds),
@@ -715,10 +765,10 @@ func main() {
 	if *recheck {
 		log.Printf("Begin to rebuild all failed packages without new changes\n")
 		recheckBuilder := &sbuild{
-			dist:   sbuildDistNorm,
-			logDir: *logDir + "_recheck",
-			keepBuildLog: *sbuildKeepBuildLog,
-			dryRun: false,
+			dist:              sbuildDistNorm,
+			logDir:            *logDir + "_recheck",
+			keepBuildLog:      *sbuildKeepBuildLog,
+			dryRun:            false,
 			extraExperimental: extraExperimental,
 			extraPockets:      extraPockets,
 			pocketsCodename:   pocketsCodename,


### PR DESCRIPTION
This commit introduces parallel package building to ratt.

- New flag `-parallel` enables parallel builds.
- New flag `-jobs` controls the number of concurrent workers (default: number of CPU cores, must be > 0).
- Added `buildPackagesSequential` and `buildPackagesParallel` helpers.
- Refactored main build loop to support sequential or parallel execution.

This allows faster builds by utilizing multiple CPU cores.

---

### Example:
```shell
~/go/bin/ratt -parallel golang-github-go-logr-zapr_1.3.0-1_amd64.changes
2025/09/12 17:09:43 Loading changes file "golang-github-go-logr-zapr_1.3.0-1_amd64.changes"
2025/09/12 17:09:43  - 1 binary packages: golang-github-go-logr-zapr-dev
2025/09/12 17:09:43 Corresponding .debs (will be injected when building):
2025/09/12 17:09:43     golang-github-go-logr-zapr-dev_1.3.0-1_all.deb
2025/09/12 17:09:43 Setting -dist=sid (from .changes file)
2025/09/12 17:09:43 Figuring out reverse build dependencies using dose-ceve(1). This might take a while
2025/09/12 17:10:14 Found 56 reverse build dependencies
2025/09/12 17:10:14 Setting -sbuild_dist=unstable (from .changes file)
2025/09/12 17:10:14 Building packages in parallel using 6 workers
2025/09/12 17:10:14 Building package 1 of 56: golang-github-containerd-stargz-snapshotter
2025/09/12 17:10:14 Building package 2 of 56: sigstore-go
2025/09/12 17:10:14 Building package 3 of 56: golang-github-containers-common
2025/09/12 17:10:14 Building package 4 of 56: golang-github-containerd-nydus-snapshotter
2025/09/12 17:10:14 Building package 4 of 56: golang-github-openshift-imagebuilder
2025/09/12 17:10:14 Building package 6 of 56: docker-compose
```