### PR TITLE
Add reverse_dep_count to JSON output and fix typo

### DIFF
--- a/ratt.go
+++ b/ratt.go
@@ -605,8 +605,12 @@ func main() {
 
 	if *dryRun && *jsonOutput {
 		out, err := json.MarshalIndent(struct {
-			Builds []dryRunBuild `json:"dry_run_builds"`
-		}{Builds: dryRunBuilds}, "", "  ")
+			ReverseDepCount     int           `json:"reverse_dep_count"`
+			Builds              []dryRunBuild `json:"dry_run_builds"`
+		}{
+			Builds:          dryRunBuilds,
+			ReverseDepCount: len(dryRunBuilds),
+		}, "", "  ")
 		if err != nil {
 			log.Fatalf("Failed to marshal JSON: %v", err)
 		}

--- a/ratt.go
+++ b/ratt.go
@@ -90,7 +90,7 @@ var (
 
 	directRdeps = flag.Bool("direct-rdeps",
 		false,
-		"Limit reverse dependency analysis to packages that directly Build-Depend on the target. Equivalent to --rdeps-depth=2")
+		"Limit reverse dependency analysis to packages that directly Build-Depend on the target. Equivalent to -rdeps-depth=2")
 
 	rdepsDepth = flag.Int("rdeps-depth",
 		0,


### PR DESCRIPTION
Improve **JSON** output by adding `reverse_dep_count` field to report the number of **reverse build-dependencies**, and fix the `-direct-rdeps` help text to use `-rdeps-depth=2` instead of `--rdeps-depth=2`